### PR TITLE
Add remove children methods to remove audio buses

### DIFF
--- a/GraphAudio.Kit/AudioBus.cs
+++ b/GraphAudio.Kit/AudioBus.cs
@@ -118,6 +118,8 @@ public sealed class AudioBus
         _gainNode.Gain.Value = _muted ? 0f : _gain;
     }
 
+    internal void RemoveChild(AudioBus child) => _childBuses.Remove(child);
+
     internal void Disconnect()
     {
         _gainNode.Disconnect();

--- a/GraphAudio.Kit/AudioEngine.cs
+++ b/GraphAudio.Kit/AudioEngine.cs
@@ -130,6 +130,18 @@ public sealed class AudioEngine : IDisposable
     }
 
     /// <summary>
+    /// Removes a bus by path, disconnecting it from its parent and the audio graph.
+    /// </summary>
+    public void RemoveBus(string path)
+    {
+        path = path.Trim().ToLowerInvariant();
+        if (!_buses.TryGetValue(path, out var bus)) return;
+        bus.Parent?.RemoveChild(bus);
+        bus.Disconnect();
+        _buses.Remove(path);
+    }
+
+    /// <summary>
     /// Creates a buffered sound from a file path.
     /// </summary>
     public async Task<BufferedSound> CreateBufferedSoundAsync(string path, SoundMixState mixState = SoundMixState.Direct, AudioBus? bus = null, CancellationToken cancellationToken = default)

--- a/GraphAudio.Kit/GraphAudio.Kit.csproj
+++ b/GraphAudio.Kit/GraphAudio.Kit.csproj
@@ -12,7 +12,7 @@
     <Authors>the-byte-bender</Authors>
     <Description>High-level audio toolkit for GraphAudio</Description>
     <Copyright>2026</Copyright>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <PackageId>GraphAudio.Kit</PackageId>
     <PackageProjectUrl>https://github.com/the-byte-bender/GraphAudio</PackageProjectUrl>
     <RepositoryUrl>https://github.com/the-byte-bender/GraphAudio</RepositoryUrl>


### PR DESCRIPTION
This PR adds methods to remove children from audio buses, and to remove audio buses when not in use anymore. 